### PR TITLE
Fixed `Edit on GitHub URL`

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,60 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Get started with MetaCall</title>
-  <meta name="description"
-        content="Documentation for developers looking to get started with MetaCall">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-  <meta name="description" content="Description">
-  <link rel="icon" href="assets/favicon.ico">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
-  <script src="//unpkg.com/docsify-edit-on-github/index.js"></script>
-  <link 
-    rel="stylesheet"
-    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
-    title="docsify-darklight-theme"
-    type="text/css"
-/>
-<style type="text/css">
-  .content {
-    overflow: auto;
-  }
-  :root {
-    --accent: var(--theme-color)!important;
-  }
-</style>
-</head>
-<body class="ready sticky">
-  <div id="app"></div>
-  <script>
-  var repo = "https://github.com/metacall/get-started";
-    window.$docsify = {
-      name: 'Getting started with MetaCall',
-      repo: repo,
-      loadSidebar: true,
-      themeColor: '#316ddb',
-      pagination: {
-        previousText: 'Previous',
-        nextText: 'Next',
-      },
-      plugins: [
-        EditOnGithubPlugin.create(
-          repo + '/blob/master/docs/',
-          null,
-          '📝 Edit on GitHub',
-        )
-      ],
-    }
-  </script>
-  <!-- Docsify v4 -->
-  <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
-  <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
-  <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
-  <script 
-    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
-    type="text/javascript">
-</script>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Get started with MetaCall</title>
+    <meta
+      name="description"
+      content="Documentation for developers looking to get started with MetaCall"
+    />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+    <meta name="description" content="Description" />
+    <link rel="icon" href="assets/favicon.ico" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0"
+    />
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css"
+    />
+    <script src="//unpkg.com/docsify-edit-on-github/index.js"></script>
+    <link
+      rel="stylesheet"
+      href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+      title="docsify-darklight-theme"
+      type="text/css"
+    />
+    <style type="text/css">
+      .content {
+        overflow: auto;
+      }
+      :root {
+        --accent: var(--theme-color) !important;
+      }
+    </style>
+  </head>
+  <body class="ready sticky">
+    <div id="app"></div>
+    <script>
+      var repo = "https://github.com/metacall/get-started";
+      window.$docsify = {
+        name: "Getting started with MetaCall",
+        repo: repo,
+        loadSidebar: true,
+        themeColor: "#316ddb",
+        pagination: {
+          previousText: "Previous",
+          nextText: "Next",
+        },
+        plugins: [
+          EditOnGithubPlugin.create(
+            repo + "/blob/main/docs/",
+            null,
+            "📝 Edit on GitHub"
+          ),
+        ],
+      };
+    </script>
+    <!-- Docsify v4 -->
+    <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
+    <script src="//unpkg.com/docsify-pagination/dist/docsify-pagination.min.js"></script>
+    <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>
+    <script
+      src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+      type="text/javascript"
+    ></script>
+  </body>
 </html>


### PR DESCRIPTION
Fixed `Edit on GitHub URL`

Currently `Edit on GitHub` is referring to :  `repo + '/blob/master/docs/'` 

Now it is fixed to :  `repo + '/blob/main/docs/'`

Now, Button Is correctly redirecting to the correct URL.